### PR TITLE
Update image to keep ansible installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ packer build --only=<type> thredds-test-env.json
 * `ami`: Provision an AWS EC2 instance and generate an AMI (`thredds-test-environment-<iso-timestamp>`)
 * `docker-commit`: Provision a Docker container and generate and tag a local Docker Image (`docker.unidata.ucar.edu/thredds-test-environment:latest`).
 * `docker-export`: Provision a Docker container and generate a local Docker Image as a file (`image.tar`).
+* `docker-github-action`: Provision a Docker container for use with GitHub Actions and publish to the GitHub Package Repository.
+* `docker-github-action-nexus`: Same as `docker-github-action`, but publish to the Unidata Nexus Repository.
 
 Typically, we would run the following to update the AMI and Docker Image at the same time:
 
@@ -132,6 +134,7 @@ We also use a role from [Ansible Galaxy](https://galaxy.ansible.com/) to setup a
 ### Bash functions:
  * `select-java <version> <vendor>` (where version is 8, 11, or 14, and vendor is `adopt` or `zulu`)
  * `activate-conda`
+ * `get_pw <key>`
 
 ### Latest version available via the OS Package Manager
   * sed

--- a/packer/provisioners/ansible/roles/security/templates/thredds_test_bash_profile.sh
+++ b/packer/provisioners/ansible/roles/security/templates/thredds_test_bash_profile.sh
@@ -78,5 +78,27 @@ function select-java() {
     fi
 }
 
+# get_pw id
+# example:
+#    get_pw password_key
+#
+# Returns the password associated with the password_key as stored in an
+# ansible vault encrypted file.
+#
+# When decrypted, each line of the vault file should be of the form
+# key=value. An environment variable, TV, must be defined and point to
+# the location of the file encrypted by ansible vault. A second
+# environment variable, AVP, should point to a file containing the
+# vault password or a script capiable of of producing the password.
+function get_pw() {
+  # Caller must supply exactly one argument.
+  if [ ! $# -eq 1 ]
+  then
+    echo "Invalid arguments. Must supply a key contained in the vault."
+  else
+    ansible-vault view --vault-password-file $AVP $TV | grep "^$1" | cut -d"=" -f2-
+  fi
+}
+
 # Update the path to pickup additions from DEFAULT_PATH variable.
 update-path

--- a/packer/provisioners/scripts/cleanup.sh
+++ b/packer/provisioners/scripts/cleanup.sh
@@ -1,20 +1,11 @@
 #!/usr/bin/bash
 set -ex
 
-# Must match what is in bootstrap-common.sh.
-ANSIBLE_CONFIG_DIR=/ansible_config
-
 # Check that we are root, and if not, use sudo to run commands.
 SUDO_CMD=""
 if [ "$EUID" -ne 0 ]; then
     SUDO_CMD="sudo"
 fi
-
-# Remove ansible.
-${SUDO_CMD} apt remove --yes ansible
-
-# Remove custom ansible config.
-${SUDO_CMD} rm -rf ${ANSIBLE_CONFIG_DIR}
 
 # Remove dangling dependencies.
 ${SUDO_CMD} apt autoremove --purge --yes

--- a/packer/thredds-test-env.json
+++ b/packer/thredds-test-env.json
@@ -75,6 +75,17 @@
         "ENV GITHUB_ACTIONS=\"YEP\"",
         "ENTRYPOINT [\"/entrypoint.sh\"]"
       ]
+    },
+    {
+      "name": "docker-github-action-nexus",
+      "type": "docker",
+      "image": "{{user `base_docker_image`}}",
+      "commit": true,
+      "changes": [
+        "USER root",
+        "ENV GITHUB_ACTIONS=\"YEP\"",
+        "ENTRYPOINT [\"/entrypoint.sh\"]"
+      ]
     }
   ],
   "provisioners": [
@@ -96,7 +107,7 @@
       "type": "file",
       "source": "provisioners/file/entrypoint.sh",
       "destination": "/entrypoint.sh",
-      "only": [ "docker-github-action" ]
+      "only": [ "docker-github-action", "docker-github-action-nexus" ]
     },
     {
       "type": "ansible-local",
@@ -126,7 +137,7 @@
     {
       "type": "shell",
       "inline": ["dos2unix /entrypoint.sh"],
-      "only": [ "docker-github-action" ]
+      "only": [ "docker-github-action", "docker-github-action-nexus" ]
     },
     {
       "type": "shell",
@@ -145,6 +156,12 @@
       "repository": "docker.pkg.github.com/unidata/thredds-test-environment/thredds-test-action",
       "tags": "latest",
       "only": [ "docker-github-action" ]
+    },
+    {
+      "type": "docker-tag",
+      "repository": "docker.unidata.ucar.edu/thredds-test-action",
+      "tags": "latest",
+      "only": [ "docker-github-action-nexus" ]
     }
   ]
 }


### PR DESCRIPTION
We now use ansible vault on jenkins to manage credentials, so we need to keep ansible in the image. In this PR, we also make sure we publish the github test action to both the unidata nexus repository as well as github packages (need to test performance differences when using the thredds-test-environment action).