### PR TITLE
select-java args & headless java 8 --> 11 boostrap fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ We also use a role from [Ansible Galaxy](https://galaxy.ansible.com/) to setup a
   * ruby (via [geerlingguy.ruby](https://galaxy.ansible.com/geerlingguy/ruby) from [Ansible Galaxy](https://galaxy.ansible.com/))
 
 ### Bash functions:
- * `select-java <version> <vendor>` (where version is 8, 11, 14, or 16, and vendor is `temurin` or `zulu`)
+ * `select-java <vendor> <version>` (where version is 8, 11, 14, or 16, and vendor is `temurin` or `zulu`)
    * note that Temurin does not have a version 14 binary at this time.
  * `activate-conda`
  * `get_pw <key>`

--- a/packer/provisioners/ansible/roles/security/templates/thredds_test_bash_profile.sh
+++ b/packer/provisioners/ansible/roles/security/templates/thredds_test_bash_profile.sh
@@ -29,7 +29,7 @@ function update-path() {
 
 # select-java vendor version
 # example:
-#    select-java 11 zulu
+#    select-java zulu 11
 #
 # vendor: [ temurin || zulu ] (no default)
 # version: [ 8 || 11 || 14 ] (no default)

--- a/packer/provisioners/scripts/bootstrap_last_aws.sh
+++ b/packer/provisioners/scripts/bootstrap_last_aws.sh
@@ -7,6 +7,6 @@ if [ "$EUID" -ne 0 ]; then
     SUDO_CMD="sudo"
 fi
 
-# Need openjdk-8-jre-headless so that jenkins can connect to worker nodes
+# Need openjdk-11-jre-headless so that jenkins can connect to worker nodes
 # using this ami.
-${SUDO_CMD} apt install --yes openjdk-8-jre-headless
+${SUDO_CMD} apt install --yes openjdk-11-jre-headless


### PR DESCRIPTION
- Change order of args in readme and commends section of the select-java bash script to be vendor then version.
- Changed the version of the jdk to 11  for jre-headless installation so that jenkins can connect to worker nodes using ami.