### PR TITLE
Use cmake to build zlib and hdf5

### DIFF
--- a/packer/provisioners/ansible/group_vars/all.yml
+++ b/packer/provisioners/ansible/group_vars/all.yml
@@ -14,10 +14,6 @@ async_poll_value_move_on: 0 # seconds
 
 default_async_timeout: 300 # seconds
 
-zlib_async_timeout: 300 # seconds (5 minutes)
-zlib_async_check_interval: 15 # seconds
-zlib_async_check_retries: 20
-
 hdf5_async_timeout: 7200 # seconds (60 minutes)
 hdf5_async_check_interval: 120 # seconds
 hdf5_async_check_retries: 80

--- a/packer/provisioners/ansible/roles/cleanup/tasks/main.yml
+++ b/packer/provisioners/ansible/roles/cleanup/tasks/main.yml
@@ -1,18 +1,19 @@
 ---
-- name: Prepare to add thredds-test-environment native libraries to run-time linker
-  copy:
-    dest: "/etc/ld.so.conf.d/tte.conf"
-    content: "{{ install_dir }}/lib"
-
 - name: Update the run-time linker cache to include any newly built libraries.
-  command: ldconfig
+  ansible.builtin.command: ldconfig
 
 - name: "Cleanup the temporary build directory."
-  file:
+  ansible.builtin.file:
     path: "{{ tmp_dir }}"
     state: absent
 
 - name: Remove packages that are not needed in final environment.
-  package:
+  ansible.builtin.apt:
     name: "{{ purgeable_packages }}"
     state: absent
+    autoremove: true
+    purge: true
+
+- name: Run the equivalent of "apt-get clean" as a separate step
+  ansible.builtin.apt:
+    clean: yes

--- a/packer/provisioners/ansible/roles/cleanup/tasks/main.yml
+++ b/packer/provisioners/ansible/roles/cleanup/tasks/main.yml
@@ -14,6 +14,6 @@
     autoremove: true
     purge: true
 
-- name: Run the equivalent of "apt-get clean" as a separate step
+- name: Run apt-get clean
   ansible.builtin.apt:
     clean: yes

--- a/packer/provisioners/ansible/roles/cleanup/vars/main.yml
+++ b/packer/provisioners/ansible/roles/cleanup/vars/main.yml
@@ -4,3 +4,4 @@
 purgeable_packages:
   - build-essential
   - m4
+  - cmake

--- a/packer/provisioners/ansible/roles/corretto/tasks/fetch_remote.yml
+++ b/packer/provisioners/ansible/roles/corretto/tasks/fetch_remote.yml
@@ -4,7 +4,7 @@
     url: "https://corretto.aws/downloads/latest/amazon-corretto-{{ item }}-x64-linux-jdk.tar.gz"
     method: GET
     follow_redirects: safe
-    dest: "/tmp/{{ base_install_name }}{{ item }}.tar.gz"
+    dest: "{{ tmp_dir }}/{{ base_install_name }}{{ item }}.tar.gz"
     # Expect 200 locally (i.e. Docker builder), 304 (for some versions) on AWS EC2.
     status_code: [200, 304]
   register: uri_result

--- a/packer/provisioners/ansible/roles/corretto/tasks/main.yml
+++ b/packer/provisioners/ansible/roles/corretto/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: Unpack Corretto Java Installations.
   unarchive:
-    src: "/tmp/{{ base_install_name }}{{ item }}.tar.gz"
+    src: "{{ tmp_dir }}/{{ base_install_name }}{{ item }}.tar.gz"
     dest: "{{ install_dir }}/{{ base_install_name }}{{ item }}"
     extra_opts: [--strip-components=1]
     creates: "{{ install_dir }}/{{ base_install_name }}{{ item }}/bin"

--- a/packer/provisioners/ansible/roles/libnetcdf-and-deps/tasks/hdf5.yml
+++ b/packer/provisioners/ansible/roles/libnetcdf-and-deps/tasks/hdf5.yml
@@ -1,6 +1,6 @@
 ---
 - name: Download and unpack hdf5.
-  unarchive:
+  ansible.builtin.unarchive:
     src: "https://github.com/HDFGroup/hdf5/releases/download/hdf5_{{ hdf5_version_full }}/hdf5-{{ hdf5_version_full }}.tar.gz"
     dest: "{{ tmp_dir }}"
     creates: "{{ hdf5_src_dir }}"
@@ -11,29 +11,68 @@
   until: unarchive_result.failed == false
 
 - name: Configure hdf5.
-  command: ./configure --prefix={{ install_dir }} --with-zlib={{ install_dir }}
+  ansible.builtin.command:
+    argv:
+      - cmake
+      - -S
+      - "{{ hdf5_src_dir }}"
+      - -B
+      - "{{ hdf5_build_dir }}"
+      - -G
+      - Unix Makefiles
+      - "-DCMAKE_BUILD_TYPE={{ hdf5_build_type }}"
+      - "-DCMAKE_INSTALL_PREFIX={{ install_dir }}"
+      - "-DCMAKE_PREFIX_PATH={{ install_dir }}/lib"
+      - -DHDF5_BUILD_TOOLS=OFF
+      - -DBUILD_STATIC_LIBS=OFF
+      - -DBUILD_SHARED_LIBS=TRUE
+      - "-DDEFAULT_API_VERSION={{ hdf5_default_api_version }}"
+      - -DHDF5_BUILD_EXAMPLES=OFF
+      - -DHDF5_ENABLE_SZIP_SUPPORT=OFF
   args:
-    chdir: "{{ hdf5_src_dir }}"
-    creates: "{{ hdf5_src_dir }}/config.log"
+    chdir: "{{ tmp_dir }}"
+    creates: "{{ hdf5_build_dir }}/CMakeCache.txt"
 
-- name: Make hdf5.
-  command: "make -j{{ make_jobs}} install"
+- name: Build hdf5.
+  ansible.builtin.command:
+    argv:
+      - cmake
+      - --build
+      - "{{ hdf5_build_dir }}"
+      - --config
+      - "{{ hdf5_build_type }}"
+      - -j
+      - "{{ make_jobs}}"
   args:
-    chdir: "{{ hdf5_src_dir }}"
+    chdir: "{{ tmp_dir }}"
+    creates: "{{ hdf5_build_dir }}/bin/libhdf5.so"
 
 - name: Install hdf5.
-  command: "make install"
+  ansible.builtin.command:
+    argv:
+      - cmake
+      - --install
+      - "{{ hdf5_build_dir }}"
+      - --config
+      - "{{ hdf5_build_type }}"
   args:
-    chdir: "{{ hdf5_src_dir }}"
+    chdir: "{{ tmp_dir }}"
     creates: "{{ install_dir }}/lib/libhdf5.so"
+
+- name: Update the run-time linker cache to include HDF5.
+  ansible.builtin.command: ldconfig
 
 # Run after install for performance reasons, as check can take quite some time
 # to run. Will check status and wait (if not finished) near the end of the
 # ansible provision process.
 - name: Test HDF5.
-  command: "make -j{{ make_jobs}} check"
+  ansible.builtin.command:
+    argv:
+      - ctest
+      - -j
+      - "{{ make_jobs }}"
   args:
-    chdir: "{{ hdf5_src_dir }}"
+    chdir: "{{ hdf5_build_dir }}"
   async: "{{ hdf5_async_timeout }}"
   poll: "{{ async_poll_value_move_on }}"
   register: async_hdf5

--- a/packer/provisioners/ansible/roles/libnetcdf-and-deps/tasks/main.yml
+++ b/packer/provisioners/ansible/roles/libnetcdf-and-deps/tasks/main.yml
@@ -15,6 +15,12 @@
     needed_packages:
       - build-essential
       - m4
+      - cmake
+
+- name: Prepare to add thredds-test-environment native libraries to run-time linker
+  copy:
+    dest: "/etc/ld.so.conf.d/tte.conf"
+    content: "{{ install_dir }}/lib"
 
 - include_tasks: zlib.yml
   tags: [ zlib ]

--- a/packer/provisioners/ansible/roles/libnetcdf-and-deps/tasks/netcdf-c.yml
+++ b/packer/provisioners/ansible/roles/libnetcdf-and-deps/tasks/netcdf-c.yml
@@ -1,6 +1,6 @@
 ---
 - name: Download and unpack netcdf-c.
-  unarchive:
+  ansible.builtin.unarchive:
     src: "https://downloads.unidata.ucar.edu/netcdf-c/{{ netcdf_version }}/netcdf-c-{{ netcdf_version }}.tar.gz"
     dest: "{{ tmp_dir }}"
     creates: "{{ netcdf_src_dir }}"
@@ -11,7 +11,7 @@
   until: unarchive_result.failed == false
 
 - name: Configure netCDF-c.
-  command: ./configure --prefix={{ install_dir }} --disable-dap --disable-utilities --disable-static --disable-nczarr --disable-libxml2 --disable-byterange
+  ansible.builtin.command: ./configure --prefix={{ install_dir }} --disable-dap --disable-utilities --disable-static --disable-nczarr --disable-libxml2 --disable-byterange
   args:
     chdir: "{{ netcdf_src_dir }}"
     creates: "{{ netcdf_src_dir }}/config.log"
@@ -25,11 +25,14 @@
     chdir: "{{ netcdf_src_dir }}"
     creates: "{{ install_dir }}/lib/libnetcdf.so"
 
+- name: Update the run-time linker cache to include netCDF-C.
+  ansible.builtin.command: ldconfig
+
 # Run after install for performance reasons, as check can take quite some time
 # to run. Will check status and wait (if not finished) near the end of the
 # ansible provision process.
 - name: Test netCDF-c.
-  command: "make -j{{ make_jobs }} check "
+  ansible.builtin.command: "make -j{{ make_jobs }} check"
   args:
     chdir: "{{ netcdf_src_dir }}"
   async: "{{ netcdf_c_async_timeout }}"

--- a/packer/provisioners/ansible/roles/libnetcdf-and-deps/tasks/zlib.yml
+++ b/packer/provisioners/ansible/roles/libnetcdf-and-deps/tasks/zlib.yml
@@ -1,6 +1,6 @@
 ---
 - name: Download and unpack zlib.
-  unarchive:
+  ansible.builtin.unarchive:
     src: https://www.zlib.net/zlib-{{ zlib_version }}.tar.gz
     dest: "{{ tmp_dir }}"
     creates: "{{ zlib_src_dir }}"
@@ -11,23 +11,53 @@
   until: unarchive_result.failed == false
 
 - name: Configure zlib.
-  command: ./configure --prefix={{ install_dir }}
+  ansible.builtin.command:
+    argv:
+      - cmake
+      - -S
+      - "{{ zlib_src_dir }}"
+      - -B
+      - "{{ zlib_build_dir }}"
+      - "-DCMAKE_BUILD_TYPE={{ zlib_build_type }}"
+      - "-DCMAKE_INSTALL_PREFIX={{ install_dir }}"
   args:
-    chdir: "{{ zlib_src_dir }}"
-    creates: "{{ zlib_src_dir }}/configure.log"
+    chdir: "{{ tmp_dir }}"
+    creates: "{{ zlib_build_dir }}/CMakeCache.txt"
+
+- name: Build zlib.
+  ansible.builtin.command:
+    argv:
+      - cmake
+      - --build
+      - "{{ zlib_build_dir }}"
+      - --config
+      - "{{ zlib_build_type }}"
+      - -j
+      - "{{ make_jobs}}"
+  args:
+    chdir: "{{ tmp_dir }}"
+    creates: "{{ zlib_build_dir }}/bin/libz.so"
+
+- name: Test zlib.
+  ansible.builtin.command:
+    argv:
+      - ctest
+      - -j
+      - "{{ make_jobs }}"
+  args:
+    chdir: "{{ zlib_build_dir }}"
 
 - name: Install zlib.
-  command: "make -j{{ make_jobs }} install"
+  ansible.builtin.command:
+    argv:
+      - cmake
+      - --install
+      - "{{ zlib_build_dir }}"
+      - --config
+      - "{{ zlib_build_type }}"
   args:
-    chdir: "{{ zlib_src_dir }}"
+    chdir: "{{ tmp_dir }}"
     creates: "{{ install_dir }}/lib/libz.so"
 
-# This does not take long to run, but will run asynchronously like the other
-# make check tasks.
-- name: Test zlib.
-  command: "make -j{{ make_jobs }} check"
-  args:
-    chdir: "{{ zlib_src_dir }}"
-  async: "{{ zlib_async_timeout }}"
-  poll: "{{ async_poll_value_move_on }}"
-  register: async_zlib
+- name: Update the run-time linker cache to include zlib.
+  ansible.builtin.command: ldconfig

--- a/packer/provisioners/ansible/roles/libnetcdf-and-deps/vars/docker.yml
+++ b/packer/provisioners/ansible/roles/libnetcdf-and-deps/vars/docker.yml
@@ -1,3 +1,3 @@
 ---
-# Use make with j4 option when using packer's docker builder.
-make_jobs: 4
+# Use make/cmake with j option when using packer's docker builder.
+make_jobs: 8

--- a/packer/provisioners/ansible/roles/libnetcdf-and-deps/vars/main.yml
+++ b/packer/provisioners/ansible/roles/libnetcdf-and-deps/vars/main.yml
@@ -1,12 +1,17 @@
 ---
 zlib_version: 1.3.1
+zlib_build_type: Release
 zlib_src_dir: "{{ tmp_dir }}/zlib-{{ zlib_version }}"
+zlib_build_dir: "{{ tmp_dir }}/zlib-build"
 
 hdf5_version_major: 1
 hdf5_version_minor: 14
 hdf5_version_point: 6
+hdf5_default_api_version: v110
+hdf5_build_type: Release
 hdf5_version_full: "{{  hdf5_version_major }}.{{ hdf5_version_minor }}.{{ hdf5_version_point }}"
 hdf5_src_dir: "{{ tmp_dir }}/hdf5-{{ hdf5_version_full }}"
+hdf5_build_dir: "{{ tmp_dir }}/hdf5-build"
 
 netcdf_version: 4.9.2
 netcdf_src_dir: "{{ tmp_dir }}/netcdf-c-{{ netcdf_version }}"

--- a/packer/provisioners/ansible/roles/temurin/tasks/fetch_remote.yml
+++ b/packer/provisioners/ansible/roles/temurin/tasks/fetch_remote.yml
@@ -4,7 +4,7 @@
     url: "https://api.adoptium.net/v3/binary/latest/{{ item }}/ga/linux/x64/jdk/hotspot/normal/eclipse?project=jdk"
     method: GET
     follow_redirects: safe
-    dest: "/tmp/{{ base_install_name }}{{ item }}.tar.gz"
+    dest: "{{ tmp_dir }}/{{ base_install_name }}{{ item }}.tar.gz"
     # Expect 200 locally (i.e. Docker builder), 304 (for some versions) on AWS EC2.
     status_code: [200, 304]
   register: uri_result

--- a/packer/provisioners/ansible/roles/temurin/tasks/main.yml
+++ b/packer/provisioners/ansible/roles/temurin/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: Unpack Temurin Java Installations.
   unarchive:
-    src: "/tmp/{{ base_install_name }}{{ item }}.tar.gz"
+    src: "{{ tmp_dir }}/{{ base_install_name }}{{ item }}.tar.gz"
     dest: "{{ install_dir }}/{{ base_install_name }}{{ item }}"
     extra_opts: [--strip-components=1]
     creates: "{{ install_dir }}/{{ base_install_name }}{{ item }}/bin"

--- a/packer/provisioners/ansible/roles/zulu/tasks/fetch_remote.yml
+++ b/packer/provisioners/ansible/roles/zulu/tasks/fetch_remote.yml
@@ -4,7 +4,7 @@
     url: "https://api.azul.com/zulu/download/community/v1.0/bundles/latest/binary/?jdk_version={{ item }}&ext=tar.gz&os=linux&arch=x86&hw_bitness=64"
     method: GET
     follow_redirects: safe
-    dest: "/tmp/{{ base_install_name }}{{ item }}.tar.gz"
+    dest: "{{ tmp_dir }}/{{ base_install_name }}{{ item }}.tar.gz"
     # Expect 200 locally (i.e. Docker builder), 304 (for some versions) on AWS EC2.
     status_code: [200, 304]
   register: uri_result

--- a/packer/provisioners/ansible/roles/zulu/tasks/main.yml
+++ b/packer/provisioners/ansible/roles/zulu/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: Unpack Zulu Java Installations.
   unarchive:
-    src: "/tmp/{{ base_install_name }}{{ item }}.tar.gz"
+    src: "{{ tmp_dir }}/{{ base_install_name }}{{ item }}.tar.gz"
     dest: "{{ install_dir }}/{{ base_install_name }}{{ item }}"
     extra_opts: [--strip-components=1]
     creates: "{{ install_dir }}/{{ base_install_name }}{{ item }}/bin"

--- a/packer/provisioners/ansible/site.yml
+++ b/packer/provisioners/ansible/site.yml
@@ -58,16 +58,6 @@
         name: thredds-test-data-mount-prep
       tags: [ thredds-test-data-mount-prep ]
 
-    # Wait for the asynchronous tasks to complete.
-    - name: Wait for zlib async test task to complete.
-      when: (async_zlib is defined) and (async_zlib|length > 0)
-      async_status:
-        jid: "{{ async_zlib.ansible_job_id }}"
-      register: job_result
-      until: job_result.finished
-      retries: "{{ zlib_async_check_interval }}"
-      delay: "{{ zlib_async_check_retries }}"
-
     - name: Wait for netcdf-c async test task to complete.
       when: (async_netcdf_c is defined) and (async_netcdf_c|length > 0)
       async_status:

--- a/packer/provisioners/scripts/bootstrap-common.sh
+++ b/packer/provisioners/scripts/bootstrap-common.sh
@@ -20,13 +20,6 @@ ${SUDO_CMD} apt upgrade --yes
 # risk getting stuck at a prompt asking us to set the timezone interactivly
 DEBIAN_FRONTEND="noninteractive" TZ="Etc/UTC" ${SUDO_CMD} apt install --yes tzdata
 
-# Once the ansiuble PPA has builds for 20.04, uncomment the next sections
-# to install ansible using it.
-# Add ansible ppa.
-# https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-ansible-on-ubuntu
-#${SUDO_CMD} apt install --yes software-properties-common
-#${SUDO_CMD} apt-add-repository --yes --update ppa:ansible/ansible
-
 # Install ansible.
 ${SUDO_CMD} apt install --yes ansible
 

--- a/packer/provisioners/scripts/cleanup.sh
+++ b/packer/provisioners/scripts/cleanup.sh
@@ -7,9 +7,6 @@ if [ "$EUID" -ne 0 ]; then
     SUDO_CMD="sudo"
 fi
 
-# Remove ansible
-${SUDO_CMD} apt remove ansible -y
-
 # Remove dangling dependencies.
 ${SUDO_CMD} apt autoremove --purge --yes
 

--- a/packer/provisioners/scripts/cleanup.sh
+++ b/packer/provisioners/scripts/cleanup.sh
@@ -7,8 +7,14 @@ if [ "$EUID" -ne 0 ]; then
     SUDO_CMD="sudo"
 fi
 
+# Remove ansible
+${SUDO_CMD} apt remove ansible -y
+
 # Remove dangling dependencies.
 ${SUDO_CMD} apt autoremove --purge --yes
 
 # Clear out the apt cache.
 ${SUDO_CMD} apt-get clean --yes
+
+# Remove package lists
+${SUDO_CMD} rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Use cmake to build zlib, hdf5

* drop async testing of zlib, use cmake
* use cmake to build hdf5 update
* update system lib path and run ldconfig after installing each of: zlib,
  hdf5, netCDF-C

Also minor fixes/enhancements to improve post-build cleanup (reduces size of image by 38%)
