### PR TITLE
Revert back to netCDF-C 4.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ We use the following roles when provisioning our images:
 
 ### netCDF-C
  * location: `/usr/thredds-test-environment`
- * version: `4.9.3`
+ * version: `4.9.2`
  * dependencies (same location):
    * zlib version: `1.3.1`
    * hdf5 version: `1.14.6`

--- a/packer/provisioners/ansible/roles/libnetcdf-and-deps/vars/main.yml
+++ b/packer/provisioners/ansible/roles/libnetcdf-and-deps/vars/main.yml
@@ -13,5 +13,5 @@ hdf5_version_full: "{{  hdf5_version_major }}.{{ hdf5_version_minor }}.{{ hdf5_v
 hdf5_src_dir: "{{ tmp_dir }}/hdf5-{{ hdf5_version_full }}"
 hdf5_build_dir: "{{ tmp_dir }}/hdf5-build"
 
-netcdf_version: 4.9.3
+netcdf_version: 4.9.2
 netcdf_src_dir: "{{ tmp_dir }}/netcdf-c-{{ netcdf_version }}"


### PR DESCRIPTION
I forgot that 4.9.3 core dumped with SIGSEGV in our extended testing, so hold we need to revert back to 4.9.2 until the next release of the C library.