### PR TITLE
User and Group ID fixes

### DIFF
--- a/packer/provisioners/ansible/group_vars/all.yml
+++ b/packer/provisioners/ansible/group_vars/all.yml
@@ -3,9 +3,6 @@
 install_dir: /usr/thredds-test-environment
 tmp_dir: /tmp/thredds-ansible-tmp
 
-# The variable thredds_test_user is defined in the packer configuration
-# located at packer/thredds-test-env.json.
-
 network_call_time_between_retries: 30 # seconds
 network_call_retries: 3
 

--- a/packer/provisioners/ansible/roles/security/tasks/main.yml
+++ b/packer/provisioners/ansible/roles/security/tasks/main.yml
@@ -5,6 +5,8 @@
 - include_tasks: ssh.yml
   tags: [ ssh ]
 
+# The variable thredds_test_user is defined in the packer configuration
+# located at packer/thredds-test-env.pkr.hcl.
 - name: Create .m2 directory for user
   file:
     path: "/home/{{ thredds_test_user }}/.m2"

--- a/packer/provisioners/ansible/roles/security/vars/main.yml
+++ b/packer/provisioners/ansible/roles/security/vars/main.yml
@@ -4,11 +4,13 @@
 custom_bash_profile_src: thredds_test_bash_profile.sh
 custom_bash_profile_dest: "/etc/profile.d/{{ custom_bash_profile_src }}"
 
+# The variables thredds_test_user, thredds_test_user_uid, and thredds_test_user_gid are
+# defined in the packer configuration located at packer/thredds-test-env.pkr.hcl.
 users:
   - name: "{{ thredds_test_user }}"
     shell: /bin/bash
-    uid: 395
-    gid: 395
+    uid: "{{ thredds_test_user_uid }}"
+    gid: "{{ thredds_test_user_gid }}"
     group: "{{ thredds_test_user }}"
 
 files2copy:

--- a/packer/provisioners/ansible/roles/thredds-test-data-mount-prep/tasks/main.yml
+++ b/packer/provisioners/ansible/roles/thredds-test-data-mount-prep/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+
+# The variable thredds_test_user is defined in the packer configuration
+# located at packer/thredds-test-env.pkr.hcl.
 - name: Ensure the '{{ cdmUnitTest_mount_dir }}' exists.
   file:
     path: "{{ cdmUnitTest_mount_dir }}"

--- a/packer/provisioners/ansible/site.yml
+++ b/packer/provisioners/ansible/site.yml
@@ -1,7 +1,7 @@
 ---
 - name: THREDDS Test Environment playbook.
   hosts: all
-  remote_user: "{{ thredds_test_user }}" # Defined in packer config
+  remote_user: "{{ thredds_test_user }}" # Defined in packer config located at packer/thredds-test-env.pkr.hcl
   become: yes
   become_method: sudo
   tasks:

--- a/packer/thredds-test-env.pkr.hcl
+++ b/packer/thredds-test-env.pkr.hcl
@@ -14,6 +14,10 @@ packer {
 locals {
   base_docker_image = "ubuntu:24.04"
   thredds_test_user = "jenkins"
+  gha_uid = "1001"
+  gha_gid = "1001"
+  jenkins_uid = "395"
+  jenkins_gid = "395"
 }
 
 source "docker" "docker-jenkins" {
@@ -62,7 +66,12 @@ build {
   provisioner "ansible-local" {
     clean_staging_directory = true
     command                 = "ANSIBLE_CONFIG=/ansible_config/ansible.cfg ANSIBLE_FORCE_COLOR=1 PYTHONUNBUFFERED=1 ansible-playbook"
-    extra_arguments         = ["--extra-vars", "\"thredds_test_user=${local.thredds_test_user}\""]
+    extra_arguments         = ["--extra-vars", "\"thredds_test_user=${local.thredds_test_user} thredds_test_user_uid=${local.jenkins_uid} thredds_test_user_gid=${local.jenkins_gid}\""]
+    override                = {
+                                docker-github-action = {
+                                  extra_arguments = ["--extra-vars", "\"thredds_test_user=${local.thredds_test_user} thredds_test_user_uid=${local.gha_uid} thredds_test_user_gid=${local.gha_gid}\""]
+                                }
+                              }
     group_vars              = "provisioners/ansible/group_vars"
     playbook_file           = "provisioners/ansible/site.yml"
     role_paths              = ["provisioners/ansible/roles/cleanup",


### PR DESCRIPTION
For GitHub actions, use 1001 for both the user and group IDs to (hopefully) address permission issues when generating test result artifacts upon failure.